### PR TITLE
Feat (transliteration): add Ukrainian letters (є, ї, і, ґ) for slug generation

### DIFF
--- a/src/utils/transliteration.ts
+++ b/src/utils/transliteration.ts
@@ -68,6 +68,16 @@ export const transliterationMap: { [key: string]: string } = {
   Э: "E",
   Ю: "Yu",
   Я: "Ya",
+  // Ukrainian (added by YuriiKosiy for Ukrainian language)
+  є: "ye",
+  ї: "yi",
+  і: "i",
+  ґ: "g",
+  // Uppercase Ukrainian (added by YuriiKosiy)
+  Є: "Ye",
+  Ї: "Yi",
+  І: "I",
+  Ґ: "G",
   // German and Nordic (consolidated)
   ä: "ae",
   ö: "oe",


### PR DESCRIPTION
Please, adds missing Ukrainian letters to the transliteration map used for slug generation. No existing logic was changed.

Changes
- src/utils/transliteration.ts:
- Add lowercase mappings: є → ye, ї → yi, і → i, ґ → g
- Add uppercase mappings: Є → Ye, Ї → Yi, І → I, Ґ → G
- Annotate the block with a comment: “added by YuriiKosiy for Ukrainian language”

Rationale
Without these mappings, slugs for Ukrainian text could be incorrect or lose characters. This improves UX and SEO for Ukrainian content while preserving current behavior for other languages.

Backward compatibility
- No existing mappings were modified.
- Russian-specific mappings remain intact (e.g., щ → sch).
- Behavior for non-Ukrainian alphabets is unchanged.

Examples (manual checks)
- "Єнот і Ґанок" → "yenot-i-ganok"
- "Їжа й Індія" → "yizha-y-indiya"
- "Україна" → "ukrayina"

Documentation
Optionally, add “Ukrainian” to the Internationalization section in README.

Credits
Changes authored by YuriiKosiy.